### PR TITLE
Fix Media Control

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
       ],
       "desktop": {
         "StartupWMClass": "apple-music-for-linux"
-      }
+      },
+      "slots": [ 
+        { "mpris": { "name": "chromium" } } 
+      ]
     }
   },
   "repository": "https://github.com/cross-platform/apple-music-for-linux",


### PR DESCRIPTION
Fixes #52 by adding the mpris slot. I was able to reproduce this issue and this fixed it for me. Tested on Linux Mint 21.1