### PR TITLE
Add region help to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 [![Snap](https://bit.ly/2ZWfetD)](https://snapcraft.io/apple-music-for-linux)
 
 ![Screenshot](https://bit.ly/2S7BOh8)
+
+# Help
+
+## Set your region
+
+```
+mkdir -p ~/snap/apple-music-for-linux/common
+echo "GB" > ~/snap/apple-music-for-linux/common/locale
+```
+
+Known regions:
+- UK: `GB`
+- Germany: `DE`

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Set your region
 
+The app should auto-detect your current location, if it fails to set the correct region for you, use the following commands to set it manually:
+
 ```
 mkdir -p ~/snap/apple-music-for-linux/common
 echo "GB" > ~/snap/apple-music-for-linux/common/locale
 ```
 
-Known regions:
-- UK: `GB`
-- Germany: `DE`
+(Replace "GB" above with the respective [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code for your country)


### PR DESCRIPTION
You must set your region to make this work outside of the US, so it's quite common that someone would want to do this.

Instead of making the user dig for these instructions, we should surface them to the readme page.

It appears that the [locale detection code](https://github.com/cross-platform/apple-music-for-linux/blob/e4ef11f797e3b6cada018223448a64e6b7d2e8bf/dump/apple-music-for-linux.launcher#L30-L31) doesn't work, at least not for me. That said I'm on version `0.7.0 2021-05-31`, but apparently this is the latest available version on Ubuntu 22.